### PR TITLE
Exclude SRI by default

### DIFF
--- a/wp-sri.php
+++ b/wp-sri.php
@@ -175,6 +175,8 @@ esc_html__('WordPress Subresource Integrity Manager is provided as free software
             } else {
                 $known_hashes[$url] = $this->hashResource($resp['body']);
                 update_option(self::prefix . 'known_hashes', $known_hashes);
+                array_push( $this->sri_exclude, esc_url( $url ) );
+                update_option( self::prefix.'excluded_hashes', $this->sri_exclude );
             }
         }
 


### PR DESCRIPTION
Add exclude to new additions (to avoid breaking new plugins unexpectedly).
For example, I forgot about google maps and only when that plugin loaded did I notice.
It would make sense for this to add hashes as excluded, and then allow users to enable the hashes as required.